### PR TITLE
Fix: Issue/126

### DIFF
--- a/source/bouncer.py
+++ b/source/bouncer.py
@@ -6,7 +6,7 @@ import logging
 from urllib.parse import urlparse
 from model import AllowDomain, Message, Channel
 from model import find_or_create_channel
-from utility import str_from_urls, urls_from_str, session, client, token, configuration, MESSAGE
+from utility import str_from_list, urls_from_str, session, client, token, configuration, MESSAGE
 from predicates import (url_http_p, url_malicious_p, allow_url_p,
                         str_contains_url_p)
 from discord_logger import DiscordLogger
@@ -95,7 +95,7 @@ async def process_message_command(message):
             session.add(AllowDomain(url_object.hostname,
                                     str(message.guild.id)))
         session.commit()
-        url_str = str_from_urls(urls)
+        url_str = str_from_list(urls)
         logger.log(MESSAGE, "URLs `%s` added to allow list.", url_str)
         await message.channel.send(_("URLs `{}` added to allow list.")
                                    .format(url_str))

--- a/source/bouncer.py
+++ b/source/bouncer.py
@@ -6,7 +6,7 @@ import logging
 from urllib.parse import urlparse
 from model import AllowDomain, Message, Channel
 from model import find_or_create_channel
-from utility import urls_from_str, session, client, token, configuration, MESSAGE
+from utility import str_from_urls, urls_from_str, session, client, token, configuration, MESSAGE
 from predicates import (url_http_p, url_malicious_p, allow_url_p,
                         str_contains_url_p)
 from discord_logger import DiscordLogger
@@ -83,7 +83,6 @@ async def process_message(message):
         # If we have made it to this point, URL is OK
         logger.log(MESSAGE, "URL marked as secure: %s", url)
 
-
 async def process_message_command(message):
     """Handle a command delivered as a message.
 
@@ -96,9 +95,10 @@ async def process_message_command(message):
             session.add(AllowDomain(url_object.hostname,
                                     str(message.guild.id)))
         session.commit()
-        logger.log(MESSAGE, "URLs `{}` added to allow list.", urls)
+        url_str = str_from_urls(urls)
+        logger.log(MESSAGE, "URLs `%s` added to allow list.", url_str)
         await message.channel.send(_("URLs `{}` added to allow list.")
-                                   .format(urls))
+                                   .format(url_str))
         return True
     elif (message.content.lower().startswith('!unallow_domains')):
         urls = urls_from_str(message.content)

--- a/source/utility.py
+++ b/source/utility.py
@@ -15,6 +15,14 @@ def urls_from_str(str):
     [!*, ]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', str)
     return urlRegex
 
+def str_from_urls(urls):
+    """Returns a human interpreted phrase from a list of urls."""
+    if len(urls) == 1:
+        return urls[0]
+    elif len(urls) == 2:
+        return urls[0] + " and " + urls[1];
+    return (urls.pop(0) + ", " + str_from_urls(urls))
+
 
 # Parse the configuration.ini file in the repository root
 configuration = configparser.ConfigParser()

--- a/source/utility.py
+++ b/source/utility.py
@@ -15,13 +15,13 @@ def urls_from_str(str):
     [!*, ]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', str)
     return urlRegex
 
-def str_from_urls(urls):
+def str_from_list(urls):
     """Returns a human interpreted phrase from a list of urls."""
     if len(urls) == 1:
         return urls[0]
     elif len(urls) == 2:
         return urls[0] + " and " + urls[1];
-    return (urls.pop(0) + ", " + str_from_urls(urls))
+    return (urls.pop(0) + ", " + str_from_list(urls))
 
 
 # Parse the configuration.ini file in the repository root


### PR DESCRIPTION
**Summary:**
Fixes #126.

**Process:**
Added a method, `str_from_urls `within `utility.py` that creates a human-like phrase given a list of URLs. 
Adapted part of the `process_message_command `definition within `bouncer.py` to utilitize the new method.

**Testing:**
_Input 1:_ `!allow_domains https://facebook.com/`
_Output 1:_ `URLs https://facebook.com/ added to allow list.`
_Input 2:_ `!allow_domains https://facebook.com/ https://google.com/`
_Output 2:_ `URLs https://facebook.com/ and https://google.com/ added to allow list.`
_Input 3:_ `!allow_domains https://facebook.com/ https://google.com/ https://microsoft.com/`
_Output 3:_ `URLs https://facebook.com/, https://google.com/ and https://microsoft.com/ added to allow list.`

**Additional Notes:**
This was adapted to the logging as well.

**Future Thoughts:**
It is definitely not important, but we may want to change `URLs` to `URL` if only one URL is being returned.