### PR TITLE
Prepend 'https' when missing in /add_to_allowlist

### DIFF
--- a/source/bouncer.py
+++ b/source/bouncer.py
@@ -131,28 +131,22 @@ async def remove_from_allowlist(ctx, url):
 @bot.slash_command()
 async def add_to_allowlist(ctx, url):
     """Allow a domain in a given server."""
-    url_object = urlparse(url)
-    netloc = url_object.netloc
+    url = urlparse(url)
+    netloc = url.netloc
 
-    allow_list = session.query(AllowDomain).filter_by(
-        server_id=ctx.guild.id).all()
-
-    is_dupe = False
-
-    for allow_domain in allow_list:
-        if allow_domain.hostname == netloc:
-            is_dupe = True
+    is_dupe = session.query(AllowDomain).filter_by(
+        server_id=ctx.guild.id, hostname=netloc).first()
 
     if is_dupe == True:
         logger.log(MESSAGE, "URL `%s` already in allow list.",
                    netloc, extra={'server': ctx.guild})
         await ctx.respond(_("Note: URL `{}` was already on the allow list.").format(netloc))
     else:
-        session.add(AllowDomain(url_object.hostname, str(ctx.guild.id)))
+        session.add(AllowDomain(url.hostname, str(ctx.guild.id)))
         session.commit()
         logger.log(MESSAGE, "URL `%s` added to allow list.",
                    url, extra={'server': ctx.guild})
-        await ctx.respond(_("URL `{}` added to allow list.").format(url))
+        await ctx.respond(_("URL `{}` added to allow list.").format(url.geturl()))
 
 
 @bot.slash_command()

--- a/source/predicates.py
+++ b/source/predicates.py
@@ -27,7 +27,8 @@ def url_malicious_p(url):
         "url": url
     }
 
-    r = requests.post("{0}/malicious_p".format(backend_base_url), json=json_payload)
+    r = requests.post(
+        "{0}/malicious_p".format(backend_base_url), json=json_payload)
     rjson = r.json()
     return rjson['malicious']
 


### PR DESCRIPTION
Prepend 'https' when missing in `/add_to_allowlist`
* Prevents duplicate URLs added to allowlist
* Alphabetizes URLs listed in `/show_allowlist`
* Fixes #185 