### PR TITLE
bouncer.py: makes #bouncer-log malicious URL messages red

### DIFF
--- a/source/bouncer.py
+++ b/source/bouncer.py
@@ -87,7 +87,8 @@ async def process_message(message):
                 await message.reply("Hey mods, if this message is safe, just type `/add_to_allowlist {0}` and then post it again."
                                     .format(url))
             await message.delete()
-            logger.log(MESSAGE, "Dangerous URL deleted: `%s`\nMessage: `'%s'`\nAuthor: `@%s`\nChannel: `#%s`",
+            # color codes below from https://www.pythondiscord.com/pages/guides/python-guides/discord-messages-with-colors/
+            logger.log(MESSAGE, f"""```ansi\n\u001b[0;0m\u001b[1;31mDangerous URL deleted: `%s`\n\nMessage: `%s`\n\nBy @%s in #%s```""",
                        url, message.content, message.author.name, message.channel.name,
                        extra={'server': message.guild})
             session.add(Message(str(message.author.id), message.content, True))

--- a/source/bouncer.py
+++ b/source/bouncer.py
@@ -88,7 +88,7 @@ async def process_message(message):
                                     .format(url))
             await message.delete()
             # color codes below from https://www.pythondiscord.com/pages/guides/python-guides/discord-messages-with-colors/
-            logger.log(MESSAGE, f"""```ansi\n\u001b[0;0m\u001b[1;31mDangerous URL deleted: `%s`\n\nMessage: `%s`\n\nBy @%s in #%s```""",
+            logger.log(MESSAGE, "```ansi\n\u001b[0;0m\u001b[1;31mDangerous URL deleted: `%s`\n\nMessage: `%s`\n\nBy @%s in #%s```",
                        url, message.content, message.author.name, message.channel.name,
                        extra={'server': message.guild})
             session.add(Message(str(message.author.id), message.content, True))


### PR DESCRIPTION
Background: A mod asked me to make malicious URL messages "pop" more in the `#bouncer-log` channel.

* et voila!

<img width="368" alt="Screenshot 2022-12-21 at 3 36 03 PM" src="https://user-images.githubusercontent.com/100495150/209024417-e6257b1f-b4c1-4fc2-bd25-98edec7085c8.png">
